### PR TITLE
Fix user inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # California Housing Price Predictor
 
+## Description
+
+This is a web application that predicts the cost of a home in California, based on data from the [1990 census](https://www.kaggle.com/datasets/camnugent/california-housing-prices)
+
 ## Getting Started
 
 ### Prerequisites
@@ -28,3 +32,13 @@
 1. Enter app folder from terminal: `cd app`
 2. Run the Flask app: `flask run` or `python3 -m flask run`
 3. A single value in the array should appear. This is the prediction from the user inputs, in dollars.
+
+## Languages & Tools
+
+- Frontend: HTML/CSS
+- Backend: Flask
+- Data Exploration: Python
+
+## Source
+
+Prediction model is trained on data from the 1990 census. More information on the dataset can be found here: [https://www.kaggle.com/datasets/camnugent/california-housing-prices](https://www.kaggle.com/datasets/camnugent/california-housing-prices)

--- a/app/app.py
+++ b/app/app.py
@@ -27,10 +27,10 @@ def hello_world():
             return render_template("index.html", error_text = "Error: Check whether all fields inputs are provided.")
         else:
             housing_age = int(request.form['housing_age'])
-            total_rooms = int(request.form['total_rooms'])
-            total_bedrooms = int(request.form['total_bedrooms'])
-            households = int(request.form['households'])
-            median_income = int(request.form['median_income'])
+            total_rooms = np.log(int(request.form['total_rooms']) + 1)
+            total_bedrooms = np.log(int(request.form['total_bedrooms']) + 1)
+            households = np.log(int(request.form['households']) + 1)
+            median_income = int(request.form['median_income']) / 10000
             ocean_proximity = request.form['ocean_proximity']
             h_ocean = 0
             inland = 0

--- a/app/static/css/index.css
+++ b/app/static/css/index.css
@@ -1,7 +1,7 @@
 .container {
     font-family: Arial, Helvetica, sans-serif;
     margin: auto;
-    width: 24rem;
+    width: 26rem;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -20,7 +20,7 @@
 
 label {
     display: flex;
-    width: 24rem;
+    width: 26rem;
     justify-content: space-between;
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,19 +8,19 @@
   <p class="header">California Housing Price Estimator</p>
   <form method="POST" class="prediction-form">
     <label for=""
-      >Housing Age: <input type="number" name="housing_age"
+      >Housing Age (Years): <input type="number" name="housing_age"
     /></label>
     <label for=""
-      >Total Rooms: <input type="number" name="total_rooms"
+      >Total Rooms (#): <input type="number" name="total_rooms"
     /></label>
     <label for=""
-      >Total Bedrooms: <input type="number" name="total_bedrooms"
+      >Total Bedrooms (#): <input type="number" name="total_bedrooms"
     /></label>
     <label for=""
-      >Number of Households: <input type="number" name="households"
+      >Number of Households (#): <input type="number" name="households"
     /></label>
     <label for=""
-      >Median Income: <input type="number" name="median_income"
+      >Median Income ($): <input type="number" name="median_income"
     /></label>
     <label for=""
       >Ocean Proximity:


### PR DESCRIPTION
Certain model parameters that the user provides require cleaning.

The following 3 parameters were normalized with a log-normal distribution: `total_rooms`, `total_bedrooms`, `households`.

`median_income` is provided to the model as a unit of tens of thousands of dollars. We allow the user to provide this parameter in single $ units, and we convert it to tens of thousands of dollars after the user provides it.